### PR TITLE
Complete installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository contains drivers for Arduino, PMOD, Grove and Raspberry PI
 peripherals connected to an IOP. Each peripheral driver comes with Jupyter
 notebooks which show how to use it. To install the notebooks run
 
-    pynq get-notebooks pynq_peripherals
+```sh
+sudo pip install git+https://github.com/Xilinx/PYNQ_peripherals.git
+sudo pynq get-notebooks pynq_peripherals -p $PYNQ_JUPYTER_NOTEBOOKS
+```
 
 in your jupyter-notebooks folder.
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     author = "PYNQ Team",
     author_email = "pynq_support@xilinx.com",
     include_package_data = True,
-    install_requires = ['pynq', 'simple_term_menu'],
+    install_requires = ['pynq>=2.6.2', 'simple_term_menu'],
     entry_points = {
         'pynq.lib': ['pynq_peripherals = pynq_peripherals'],
         'pynq.notebooks': ['pynq_peripherals = pynq_peripherals.notebooks'],


### PR DESCRIPTION
- Add command to pip install repository directly from github 
- Add `pynq` >= 2.6.2 as requirement 